### PR TITLE
Use a dedicated thread for watching sayAllHandler existence

### DIFF
--- a/addon/synthDrivers/UML.py
+++ b/addon/synthDrivers/UML.py
@@ -8,7 +8,6 @@ from speech.commands import IndexCommand, LangChangeCommand
 import speech
 import queue
 import threading
-import wx
 from . import _umlCodes
 
 # On NVDA startup, SynthDriver objects are imported first. If confspec is in UML GlobalPlugin, accessing to the config values seems to make an invalid cache and breaks UML config. Define conficspec here.

--- a/addon/synthDrivers/UML.py
+++ b/addon/synthDrivers/UML.py
@@ -67,6 +67,7 @@ def _execWhenDone(func, *args, mustBeAsync=True, **kwargs):
 
 class SayAllWatcher(threading.Thread):
     """On NVDA startup, sayAllHandler is not instantiated by NVDA. We want to hook into the object. So we use a dedicated background thread for watching sayAllHandler existence."""
+
     def run(self):
         while(True):
             if speech.sayAll.SayAllHandler is None:
@@ -131,7 +132,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         # Hook into NVDA internal, an evil cat!
         self.setHook()
 
-
     def setHook(self):
         global origSpeak, UMLInstance
         origSpeak = speech.speech.speak
@@ -142,7 +142,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         w = SayAllWatcher()
         w.setDaemon(True)
         w.start()
-
 
     def terminate(self):
         global isHooking
@@ -161,7 +160,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         synthDriverHandler.synthIndexReached.unregister(self.on_index)
         bgQueue.put((None, None, None))
         self.thread.join()
-
 
     def speak(self, seq):
         synth = self.synthInstanceMap[self.last_lang]


### PR DESCRIPTION
Recursion errors were occurring by doing the following:
- Launch NVDA which is set to load UML by default
- Switch to another synthDriver
- Switch back to UML

This was because UML was failing to hook into sayAllHandler. UML could not hook into it because NVDA did not instantiate sayAllHandler at the time that UML was loaded. So I made a dedicated background thread to watch for sayAllHandler existence, and performed lazy-hooking.