### PR TITLE
Resolves #32 Fix deadlock when speech sequence contains no text

### DIFF
--- a/addon/synthDrivers/UML.py
+++ b/addon/synthDrivers/UML.py
@@ -193,6 +193,20 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         _execWhenDone(self.notify_done)
 
     def wait_speak(self, synth, seq):
+        # If seq contains no text (e.g. only IndexCommands from a language switch
+        # boundary), skip the engine entirely and fire index notifications directly.
+        # Without this, two deadlocks can occur:
+        #   1. Some engines (OneCore, SAPI5) never fire synthDoneSpeaking for
+        #      text-less sequences, so done.wait() blocks forever.
+        #   2. HISS may run indexReached synchronously on the calling thread when
+        #      there is no text, which re-enters self.lock and deadlocks.
+        if not any(isinstance(item, str) for item in seq):
+            for item in seq:
+                if isinstance(item, IndexCommand):
+                    synthDriverHandler.synthIndexReached.notify(
+                        synth=self, index=item.index
+                    )
+            return
         with self.lock:
             self.done.clear()
             self.cur_synth = synth


### PR DESCRIPTION
## Summary

- Fixes a deadlock in `wait_speak()` that causes NVDA to go completely silent and requires a restart
- The bug is triggered when a language switch boundary produces a speech sequence containing only `IndexCommand`s with no text strings (e.g. when navigating to a blank line or across language boundaries)
- Two deadlock mechanisms were identified and fixed:
  1. **OneCore/SAPI5**: never fire `synthDoneSpeaking` for text-less sequences, so `done.wait()` blocks the BgThread forever
  2. **HISS**: runs `indexReached` synchronously on the calling thread when there is no text, which re-enters `self.lock` already held by `wait_speak()`, causing a deadlock

## Fix

Early return in `wait_speak()` when seq has no text strings — fire `IndexCommand` notifications directly and skip the engine entirely. This avoids both the lock and `done.wait()`.

## Reproduction

1. Use UML with any engine combination (OneCore, SAPI5, HISS)
2. Navigate to a line containing only whitespace, or navigate across a language boundary where an `IndexCommand` precedes a `LangChangeCommand`
3. NVDA goes completely silent until restarted

Fixes #32

## Test plan

- [ ] Read through a document containing blank lines — verify speech continues normally
- [ ] Navigate by character across language boundaries — verify no freeze
- [ ] Test with HISS as Japanese engine and OneCore/SAPI5 as fallback
- [ ] Test with both `word` and `sentence` splitting strategies

🤖 Generated with [Claude Code](https://claude.com/claude-code)