### PR TITLE
feat: add UML ring rate/volume with per-language offsets

### DIFF
--- a/addon/globalPlugins/UML/__init__.py
+++ b/addon/globalPlugins/UML/__init__.py
@@ -27,6 +27,10 @@ confspec = {
     "japanese": "string(default=_)",
     "fallback": "string(default=_)",
     "checkForUpdatesOnStartup": "boolean(default=True)",
+    "volumeOffset_ja": "integer(default=0, min=-100, max=100)",
+    "volumeOffset_en": "integer(default=0, min=-100, max=100)",
+    "rateOffset_ja": "integer(default=0, min=-100, max=100)",
+    "rateOffset_en": "integer(default=0, min=-100, max=100)",
 }
 config.conf.spec["UML_global"] = confspec
 
@@ -87,6 +91,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             "primary_language": config.conf["UML_global"]["primaryLanguage"],
             "strategy": config.conf["UML_global"]["strategy"],
             "engineMap": engineMap,
+            "volumeOffset_ja": config.conf["UML_global"]["volumeOffset_ja"],
+            "volumeOffset_en": config.conf["UML_global"]["volumeOffset_en"],
+            "rateOffset_ja": config.conf["UML_global"]["rateOffset_ja"],
+            "rateOffset_en": config.conf["UML_global"]["rateOffset_en"],
         }
         dlg = SettingsDialog(opts)
         ret = dlg.ShowModal()
@@ -101,6 +109,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         config.conf["UML_global"]["strategy"] = data["strategy"]
         config.conf["UML_global"]["japanese"] = data["engineMap"]["ja"]
         config.conf["UML_global"]["fallback"] = data["engineMap"]["en"]
+        config.conf["UML_global"]["volumeOffset_ja"] = data["volumeOffset_ja"]
+        config.conf["UML_global"]["volumeOffset_en"] = data["volumeOffset_en"]
+        config.conf["UML_global"]["rateOffset_ja"] = data["rateOffset_ja"]
+        config.conf["UML_global"]["rateOffset_en"] = data["rateOffset_en"]
+        synth = synthDriverHandler.getSynth()
+        if synth and synth.name == "UML":
+            synth._applySettings()
         if synthDriverHandler.getSynth().name == "UML":
             self._askHotReload(backup)
 

--- a/addon/globalPlugins/UML/settings.py
+++ b/addon/globalPlugins/UML/settings.py
@@ -75,7 +75,46 @@ class SettingsDialog(wx.Dialog):
         msz.Add(enginesLabel)
         msz.Add(self.enginesList, 0, wx.EXPAND)
         msz.Add(self.selectEngineButton, 1, wx.ALIGN_RIGHT)
-        msz.AddSpacer(40)
+        msz.AddSpacer(20)
+
+        adjLabel = wx.StaticText(self, wx.ID_ANY, label=_("Voice adjustments"))
+        msz.Add(adjLabel)
+        msz.AddSpacer(5)
+
+        offsetMin = -100
+        offsetMax = 100
+        self.volumeOffsets = {}
+        self.rateOffsets = {}
+        for lang in self.langValues:
+            code = lang["internal"]
+            name = lang["user"]
+
+            volName = _("%s volume adjustment (%d to %d)") % (
+                name, offsetMin, offsetMax)
+            volLabel = wx.StaticText(self, wx.ID_ANY, label=volName)
+            self.volumeOffsets[code] = wx.SpinCtrl(
+                self, wx.ID_ANY, min=offsetMin, max=offsetMax,
+                initial=opts.get("volumeOffset_%s" % code, 0),
+                name=volName)
+            vsz = wx.BoxSizer(wx.HORIZONTAL)
+            vsz.Add(volLabel, 1)
+            vsz.Add(self.volumeOffsets[code], 1)
+            msz.Add(vsz, 0, wx.EXPAND)
+
+            rateName = _("%s rate adjustment (%d to %d)") % (
+                name, offsetMin, offsetMax)
+            rateLabel = wx.StaticText(self, wx.ID_ANY, label=rateName)
+            self.rateOffsets[code] = wx.SpinCtrl(
+                self, wx.ID_ANY, min=offsetMin, max=offsetMax,
+                initial=opts.get("rateOffset_%s" % code, 0),
+                name=rateName)
+            rsz = wx.BoxSizer(wx.HORIZONTAL)
+            rsz.Add(rateLabel, 1)
+            rsz.Add(self.rateOffsets[code], 1)
+            msz.Add(rsz, 0, wx.EXPAND)
+            msz.AddSpacer(5)
+
+        msz.AddSpacer(20)
 
         ok = wx.Button(self, wx.ID_OK, _("OK"))
         ok.SetDefault()
@@ -126,11 +165,16 @@ class SettingsDialog(wx.Dialog):
         return ""
 
     def GetData(self):
-        return {
+        data = {
             "primary_language": self.langValues[self.langList.GetSelection()]["internal"],
             "strategy": self.strategyValues[self.strategyList.GetSelection()]["internal"],
             "engineMap": self.engineMap,
         }
+        for lang in self.langValues:
+            code = lang["internal"]
+            data["volumeOffset_%s" % code] = self.volumeOffsets[code].GetValue()
+            data["rateOffset_%s" % code] = self.rateOffsets[code].GetValue()
+        return data
 
     def onSynthSelect(self, evt):
         selected = self.enginesList.GetFocusedItem()

--- a/addon/locale/ja/LC_MESSAGES/nvda.po
+++ b/addon/locale/ja/LC_MESSAGES/nvda.po
@@ -170,6 +170,20 @@ msgstr "エンジン"
 msgid "Select engine"
 msgstr "エンジンを選択"
 
+#: addon\globalPlugins\UML\settings.py:80
+msgid "Voice adjustments"
+msgstr "音声調整"
+
+#: addon\globalPlugins\UML\settings.py:92
+#, python-format
+msgid "%s volume adjustment (%d to %d)"
+msgstr "%s 音量調整 (%d から %d)"
+
+#: addon\globalPlugins\UML\settings.py:104
+#, python-format
+msgid "%s rate adjustment (%d to %d)"
+msgstr "%s 速度調整 (%d から %d)"
+
 #: addon\globalPlugins\UML\settings.py:117
 msgid "Not set"
 msgstr "未設定"

--- a/addon/synthDrivers/UML.py
+++ b/addon/synthDrivers/UML.py
@@ -3,6 +3,7 @@
 # Some code provided by the NVDA community
 
 import config
+from logHandler import log
 import synthDriverHandler
 from speech.commands import IndexCommand, LangChangeCommand
 import speech
@@ -17,6 +18,10 @@ confspec = {
     "japanese": "string(default=_)",
     "fallback": "string(default=_)",
     "checkForUpdatesOnStartup": "boolean(default=True)",
+    "volumeOffset_ja": "integer(default=0, min=-100, max=100)",
+    "volumeOffset_en": "integer(default=0, min=-100, max=100)",
+    "rateOffset_ja": "integer(default=0, min=-100, max=100)",
+    "rateOffset_en": "integer(default=0, min=-100, max=100)",
 }
 config.conf.spec["UML_global"] = confspec
 
@@ -83,7 +88,10 @@ class SayAllWatcher(threading.Thread):
 class SynthDriver(synthDriverHandler.SynthDriver):
     name = 'UML'
     description = 'Universal multilingual'
-    supportedSettings = ()
+    supportedSettings = (
+        synthDriverHandler.SynthDriver.VolumeSetting(),
+        synthDriverHandler.SynthDriver.RateSetting(),
+    )
     supportedCommands = {IndexCommand, }
     supportedNotifications = {
         synthDriverHandler.synthIndexReached, synthDriverHandler.synthDoneSpeaking
@@ -98,7 +106,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         self.strategy = "word"
         if "strategy" in config.conf["UML_global"]:
             self.strategy = config.conf["UML_global"]["strategy"]
-        self    .primary_lang = "ja"
+        self.primary_lang = "ja"
         if "primaryLanguage" in config.conf["UML_global"]:
             # For some reason, primaryLanguage might be inaccessible on NVDA startup. Still haven't figured out why. Maybe configSpec is not loaded yet?
             self.primary_lang = config.conf["UML_global"]["primaryLanguage"]
@@ -114,12 +122,13 @@ class SynthDriver(synthDriverHandler.SynthDriver):
                 synth = synthDriverHandler._getSynthDriver(v)()
                 synth.initSettings()
                 self.synthInstanceMap[k] = synth
-                print("synth added as key %s" % k)
             except BaseException as e:
                 raise InitializationError(
                     "Failed to load %s (reason: %s)" % (v, e))
             # end wrap errors on exception
         # end load synth for all languages
+        self._volume = 100
+        self._rate = 50
         self.cur_synth = None
         self.lock = threading.Lock()
         self.lastindex = None
@@ -162,7 +171,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         self.thread.join()
 
     def speak(self, seq):
-        print("last_lang: %s, dictionary keys: %s" % (self.last_lang, list(self.synthInstanceMap.keys())))
         synth = self.synthInstanceMap[self.last_lang]
         textList = []
         for i, item in enumerate(seq):
@@ -176,7 +184,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
                     textList = []
                 # end textList exists
                 self.last_lang = code
-                print("last_lang: %s" % code)
                 if code == 'en':
                     synth = self.synthInstanceMap['en']
                 else:
@@ -210,14 +217,15 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         with self.lock:
             self.done.clear()
             self.cur_synth = synth
+            self._applySynthSettings(synth)
             synth.speak(seq)
         self.done.wait()
 
     def cancel(self):
         try:
             while True:
-                item = bgQueue .get_nowait()
-                bgQueue .task_done()
+                item = bgQueue.get_nowait()
+                bgQueue.task_done()
         except queue.Empty:
             pass
 
@@ -245,6 +253,54 @@ class SynthDriver(synthDriverHandler.SynthDriver):
     @property
     def language(self):
         return self.last_lang
+
+    def _get_volume(self):
+        return self._volume
+
+    def _set_volume(self, value):
+        self._volume = value
+        self._applySettings()
+
+    def _get_rate(self):
+        return self._rate
+
+    def _set_rate(self, value):
+        self._rate = value
+        self._applySettings()
+
+    @staticmethod
+    def _clampPercent(value):
+        return max(0, min(100, int(value)))
+
+    def _getOffset(self, kind, lang):
+        try:
+            return int(config.conf["UML_global"]["%sOffset_%s" % (kind, lang)])
+        except Exception:
+            return 0
+
+    def _applyLangSettings(self, lang, synth):
+        eff_rate = self._clampPercent(self._rate + self._getOffset("rate", lang))
+        eff_vol = self._clampPercent(self._volume + self._getOffset("volume", lang))
+        try:
+            synth.rate = eff_rate
+        except Exception:
+            pass
+        try:
+            synth.volume = eff_vol
+        except Exception:
+            pass
+
+    def _applySynthSettings(self, synth):
+        for lang, candidate in self.synthInstanceMap.items():
+            if candidate is synth:
+                self._applyLangSettings(lang, synth)
+                return
+
+    def _applySettings(self):
+        if not hasattr(self, "synthInstanceMap") or not self.synthInstanceMap:
+            return
+        for lang, synth in self.synthInstanceMap.items():
+            self._applyLangSettings(lang, synth)
 
 
 def stringsplit(s, last_lang, strategy):


### PR DESCRIPTION
## Summary
- Add UML master Rate/Volume controls to the NVDA synth ring (`supportedSettings`).
- Add per-language rate/volume offsets for Japanese and Non-Japanese in UML settings.
- Apply offset changes immediately when saved.
- Clarify adjustment labels with explicit range text `(-100 to 100)`.

## Design Logic: Rate/Volume vs RateBoost
UML now computes effective rate and volume as:

`effective = clamp(master_from_UML_ring + per_language_offset, 0, 100)`

This unifies behavior across underlying engines because rate/volume are broadly compatible as 0..100 style controls.

RateBoost is intentionally not unified at UML level and remains inherited from each underlying engine's own settings/state.

Why:
- RateBoost semantics are backend-specific.
- Some engines expose RateBoost as numeric values, others as boolean-like toggles.
- A single UML RateBoost would require per-backend conversion/mapping logic.
- That mapping is fragile and higher-maintenance, and not necessary for the main use case.

So the design is:
- `rate` / `volume`: controlled by UML ring + offsets.
- `rateBoost`: left to each backend engine's native setting.
