### PR TITLE
fix: show reload dialog only when speech engine changes

### DIFF
--- a/addon/globalPlugins/UML/__init__.py
+++ b/addon/globalPlugins/UML/__init__.py
@@ -105,6 +105,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     def _saveSettings(self, data):
         # If the new settings fail, revert to the previous one.
         backup = list(config.conf["UML_global"].items())
+        old_japanese = config.conf["UML_global"]["japanese"]
+        old_fallback = config.conf["UML_global"]["fallback"]
         config.conf["UML_global"]["primaryLanguage"] = data["primary_language"]
         config.conf["UML_global"]["strategy"] = data["strategy"]
         config.conf["UML_global"]["japanese"] = data["engineMap"]["ja"]
@@ -116,7 +118,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         synth = synthDriverHandler.getSynth()
         if synth and synth.name == "UML":
             synth._applySettings()
-        if synthDriverHandler.getSynth().name == "UML":
+        engine_changed = (
+            data["engineMap"]["ja"] != old_japanese
+            or data["engineMap"]["en"] != old_fallback
+        )
+        if engine_changed and synthDriverHandler.getSynth().name == "UML":
             self._askHotReload(backup)
 
     def _askHotReload(self, backup):


### PR DESCRIPTION
Previously, saving the UML settings dialog always triggered a reload confirmation prompt whenever UML was the active synthesizer. This was unnecessary for settings that take effect immediately via _applySettings() (volume offset, rate offset, primary language, strategy).

Now the reload dialog is only shown when the Japanese or fallback engine selection has actually changed, since those changes require a full synthesizer reload to take effect.