### PR TITLE
Support NVDA 2025 buildVersion module import

### DIFF
--- a/addon/globalPlugins/UML/compat.py
+++ b/addon/globalPlugins/UML/compat.py
@@ -1,9 +1,13 @@
 import wx
 import gui
-import versionInfo
+
+try:
+    import buildVersion as _versionInfo
+except ImportError:
+    import versionInfo as _versionInfo
 
 def isCompatibleWith2025():
-    return versionInfo.version_year >= 2025
+    return _versionInfo.version_year >= 2025
 
 def messageBox(message, title):
     if isCompatibleWith2025():

--- a/addon/globalPlugins/UML/updater.py
+++ b/addon/globalPlugins/UML/updater.py
@@ -9,7 +9,10 @@ import sys
 import tempfile
 import threading
 import time
-import versionInfo
+try:
+    import buildVersion as _versionInfo
+except ImportError:
+    import versionInfo as _versionInfo
 import winreg
 import wx
 from logHandler import log
@@ -34,7 +37,7 @@ AUTO=0
 MANUAL=1
 
 def isCompatibleWith2025():
-    return versionInfo.version_year >= 2025
+    return _versionInfo.version_year >= 2025
 
 def messageBox(message, title):
     if isCompatibleWith2025():


### PR DESCRIPTION
## Summary
Updated version detection to support NVDA 2025's new `buildVersion` module while maintaining backward compatibility with older NVDA versions that use `versionInfo`.

## Key Changes
- Modified `addon/globalPlugins/UML/compat.py` to attempt importing `buildVersion` first, falling back to `versionInfo` if unavailable
- Modified `addon/globalPlugins/UML/updater.py` with the same import strategy
- Updated all version checks to use the aliased `_versionInfo` module reference
- Maintained backward compatibility with NVDA versions prior to 2025

## Implementation Details
Both files now use a try-except pattern to handle the module import difference:
- Attempts to import `buildVersion` (NVDA 2025+)
- Falls back to `versionInfo` (NVDA < 2025) if the import fails
- All references to version information use the `_versionInfo` alias to work with either module

This approach ensures the addon works seamlessly across NVDA versions without requiring separate code paths.

https://claude.ai/code/session_012ZobFRpzKZTC6vmxJ99DJm